### PR TITLE
Format date and time according to current timezone

### DIFF
--- a/static/js/little_helpers.js
+++ b/static/js/little_helpers.js
@@ -17,7 +17,6 @@ function formatDate(id,dat){
 
   const current_tz = getUrlParameter('tz') || moment.tz.guess();
 
-  console.log(dat)
   let atime = moment(dat).clone().tz(current_tz)
 
   hid.html("<span>"+atime.format("MMMM, Do MMM YYYY")+":</span>")

--- a/static/js/little_helpers.js
+++ b/static/js/little_helpers.js
@@ -12,17 +12,33 @@ function setQueryStringParameter(name, value) {
     window.history.replaceState({}, "", decodeURIComponent(`${window.location.pathname}?${params}`));
 }
 
-function getLocalTime(t){
-  // TODO those variables should be in some config files, not hardcoded here
-  var default_timezone="America/Denver"
-  var print_date_format = "LLL"
+function formatDate(id,dat){
+  var hid = $("#"+id)
 
-  var sel = document.getElementById('tzOptions')
-  current_tz = sel.options[sel.selectedIndex].value
+  const current_tz = getUrlParameter('tz') || moment.tz.guess();
 
-  let otime = moment.tz(t,default_timezone)
-  let newtime = otime.clone().tz(current_tz)
-  return newtime.format(print_date_format)
+  console.log(dat)
+  let atime = moment(dat).clone().tz(current_tz)
+
+  hid.html("<span>"+atime.format("MMMM, Do MMM YYYY")+":</span>")
+
+}
+
+function formatDateTime(id,start,end){
+  var hid = $("#"+id)
+
+  const current_tz = getUrlParameter('tz') || moment.tz.guess();
+
+  let starttime = moment(start).clone().tz(current_tz)
+  let endtime = moment(end).clone().tz(current_tz)
+
+  //if(starttime.diff(endtime, "days") <= 0) // Making difference between the "D" numbers because the diff function
+                                             // seems like not considering the timezone
+  if(starttime.format("D") == endtime.format("D"))
+    hid.html("<span>"+starttime.format("hh:mm A")+"</span>&ndash;<span>"+endtime.format("hh:mm A")+"</span>")
+  else
+    hid.html("<span>"+starttime.format("MMM Do hh:mm A")+"</span>&ndash;<span>"+endtime.format("MMM Do hh:mm A")+"</span>")
+  
 }
 
 const initTypeAhead = (list, css_sel, name, callback) => {

--- a/static/js/little_helpers.js
+++ b/static/js/little_helpers.js
@@ -12,6 +12,18 @@ function setQueryStringParameter(name, value) {
     window.history.replaceState({}, "", decodeURIComponent(`${window.location.pathname}?${params}`));
 }
 
+function getLocalTime(t){
+  // TODO those variables should be in some config files, not hardcoded here
+  var default_timezone="America/Denver"
+  var print_date_format = "LLL"
+
+  var sel = document.getElementById('tzOptions')
+  current_tz = sel.options[sel.selectedIndex].value
+
+  let otime = moment.tz(t,default_timezone)
+  let newtime = otime.clone().tz(current_tz)
+  return newtime.format(print_date_format)
+}
 
 const initTypeAhead = (list, css_sel, name, callback) => {
     const bh = new Bloodhound({

--- a/templates/components.html
+++ b/templates/components.html
@@ -37,14 +37,16 @@
 {% for timeslot in sessions_by_time %}
 <div class="row pt-5">
   <div class="col-md-12">
-    <h1><!--{{ sessions_by_time[timeslot].date }}: --><script>document.write(getLocalTime("{{ sessions_by_time[timeslot].startTime }}"))</script> &ndash; <script>document.write(getLocalTime("{{ sessions_by_time[timeslot].endTime }}"))</script></h1>
+    <h1 id="d_{{ sessions_by_time[timeslot].sessions[0].id }}"></h1>
+    <script type="text/javascript">formatDate("d_{{sessions_by_time[timeslot].sessions[0].id}}","{{ sessions_by_time[timeslot].sessions[0].startTime }}")</script>
   </div>
 </div>
 {% for session in sessions_by_time[timeslot].sessions %}
 <div class="row py-3">
 <div class="col-md-12 session-listing" style="border-color: {{ config_calendar_colors[session.type] }};">
     <h3><a href="session_{{session.id}}.html">{{ session.title }}</a></h3>
-    <h4><script>document.write(getLocalTime("{{ session.startTime }}"))</script> &ndash; <script>document.write(getLocalTime("{{ session.endTime }}"))</script></h4>
+    <h4 id="dt_{{session.id}}"></h4>
+    <script type="text/javascript">formatDateTime("dt_{{session.id}}","{{ session.startTime }}","{{ session.endTime }}")</script>
     <p>Type: {{ session.type }}</p>
   </div>
 </div>

--- a/templates/components.html
+++ b/templates/components.html
@@ -37,14 +37,14 @@
 {% for timeslot in sessions_by_time %}
 <div class="row pt-5">
   <div class="col-md-12">
-    <h1>{{ sessions_by_time[timeslot].date }}: {{ sessions_by_time[timeslot].startTime }} &ndash; {{ sessions_by_time[timeslot].endTime }}</h1>
+    <h1><!--{{ sessions_by_time[timeslot].date }}: --><script>document.write(getLocalTime("{{ sessions_by_time[timeslot].startTime }}"))</script> &ndash; <script>document.write(getLocalTime("{{ sessions_by_time[timeslot].endTime }}"))</script></h1>
   </div>
 </div>
 {% for session in sessions_by_time[timeslot].sessions %}
 <div class="row py-3">
 <div class="col-md-12 session-listing" style="border-color: {{ config_calendar_colors[session.type] }};">
     <h3><a href="session_{{session.id}}.html">{{ session.title }}</a></h3>
-    <h4>{{ session.startTime }} &ndash; {{ session.endTime }}</h4>
+    <h4><script>document.write(getLocalTime("{{ session.startTime }}"))</script> &ndash; <script>document.write(getLocalTime("{{ session.endTime }}"))</script></h4>
     <p>Type: {{ session.type }}</p>
   </div>
 </div>

--- a/todo.txt
+++ b/todo.txt
@@ -11,7 +11,7 @@
 [X] organization of sessions per-day by timeslot
 [X] adding specific-day calendars on each page
 [ ] calendar: add color legend (session type to color mapping)
-[ ] calendar: add tooltips for displaying full event name on calendar event hover
+[ ] calendar: add tooltips for displaying full event name on calendar event hover (steve: the calendar library allows to show nice tooltips if we enable "useDetailPopup: true" but only on click (not on hover), should we make a clone and edit the library ?? )
 [ ] calendar: calendars on other tabs are not aligning events correctly (does work on hard-reload)
 [ ] session listing: parse and format dates based on current timezone through javascript
 [ ] day listing: better support non-US timezones when a single day's events straddle multiple days


### PR DESCRIPTION
This is an attempt to format the dates and time in the schedule according to the current timezone. 
Some notes:

- Dates in the titles ("h1") are updated according to the first session in that time slot (in the selected timezone)
- when start and end dates differ in the current timezone the start and end days are also listed
- if start and end days are the same we only report the time slot

The formats can be changed in the functions formatDate() and formatDateTime() in little_helpers.js